### PR TITLE
Minor package.json fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,14 @@
   "bugs": {
     "url": "https://github.com/doowb/snake-cli/issues"
   },
-  "license": "Released under the MIT license.",
+  "license": "MIT",
   "files": [
     "cli.js",
-    "index.js",
-    "LICENSE"
+    "index.js"
   ],
-  "main": "index.js",
   "preferGlobal": true,
   "bin": {
-    "snake": "./cli.js"
+    "snake": "cli.js"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
- Use SPDX identifier for "license"
- "main" defaults to index.js
- file paths are always relative to package.json
- LICENSE file is automatically included

https://docs.npmjs.com/files/package.json
